### PR TITLE
Fix sample of relationship model.

### DIFF
--- a/common-data-model/model-json.md
+++ b/common-data-model/model-json.md
@@ -283,15 +283,15 @@ Sample:
 ```
     "relationships": [
         {
-            "$type": " SingleKeyRelationship ",
-            "fromAttribute": [
+            "$type": "SingleKeyRelationship",
+            "fromAttribute": {
                 "entityName": "Account",
                 "attributeName": "ContactId",
-           ],
-            "toAttribute": [ 
+           },
+            "toAttribute": { 
                 "entityName": "Contact",
                 "attributeName": "Id",
-           ]
+           }
         },
     ]
 ```


### PR DESCRIPTION
The sample of "relationship" model contains mistakes.
1. $type property has unnecessary whitespace
2. Brackets of "fromAttribute" and "toAttribute" are invalid.