### PR TITLE
Remove IsDerivedFrom from CdmObjectDefinition class

### DIFF
--- a/common-data-model/0.9om/api-reference/cdm/cdmobjectdefinition.md
+++ b/common-data-model/0.9om/api-reference/cdm/cdmobjectdefinition.md
@@ -28,6 +28,6 @@ public interface CdmObjectDefinition extends CdmObject
 |Name|Description|Return Type|
 |---|---|---|
 |**GetName()**|All object definitions have some kind of name, so this method returns the name independent from the *name* property.|string|
-|**IsDerivedFrom(string, [ResolveOptions](../utilities/resolveoptions.md))**<br/>*baseDef*: The name of the object that we want to check whether this object is derived from it.<br/>*resOpt [optional]*: The resolve options.|Returns true if the object (or the referenced object) is an extension of the specified symbol name in some way.|bool|
+
 
 


### PR DESCRIPTION
IsDerivedFrom is already defined in base class CdmObject, so it is not necessary to have it declared in this class.