### PR TITLE
[BULK] - DocuTune remediation - Sensitive terms with GUIDs

### DIFF
--- a/common-data-model/creating-schemas.md
+++ b/common-data-model/creating-schemas.md
@@ -837,7 +837,7 @@ cdmCorpus.Storage.Mount("cdm", new LocalAdapter(pathFromExeToExampleRoot + "exam
 //    new ADLSAdapter(
 //      "<ACCOUNT-NAME>.dfs.core.windows.net", // Hostname.
 //      "/<FILESYSTEM-NAME>", // Root.
-//      "72f988bf-86f1-41af-91ab-2d7cd011db47",  // Tenant ID.
+//      "aaaabbbb-0000-cccc-1111-dddd2222eeee",  // Tenant ID.
 //      "<CLIENT-ID>",  // Client ID.
 //      "<CLIENT-SECRET>" // Client secret.
 //    )

--- a/common-data-model/creating-schemas.md
+++ b/common-data-model/creating-schemas.md
@@ -881,7 +881,7 @@ cdmCorpus.Storage.Mount("cdm", new LocalAdapter(@"C:\path\to\CDM\schemaDocuments
 //    new ADLSAdapter(
 //      "<ACCOUNT-NAME>.dfs.core.windows.net", // Hostname.
 //      "/<FILESYSTEM-NAME>", // Root.
-//      "72f988bf-86f1-41af-91ab-2d7cd011db47",  // Tenant ID.
+//      "aaaabbbb-0000-cccc-1111-dddd2222eeee",  // Tenant ID.
 //      "<CLIENT-ID>",  // Client ID.
 //      "<CLIENT-SECRET>" // Client secret.
 //    )


### PR DESCRIPTION
Applying sensitive terms with GUID changes as part of Content SFI and outlined in [Overview - Writing content securely - Platform Manual](https://review.learn.microsoft.com/en-us/help/platform/security-reference?branch=main). Changes are part of the Microsoft-wide SFI effort. Point of contact: @CelesteDG

DocuTune v1.5.2.0
CorrelationId: [ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db](https://github.com/MicrosoftDocs/azure-docs-pr/pulls?q=is%3Apr+ac15aa43-4e2b-437f-ab1c-fdd7e79cd4db+)

#docutune